### PR TITLE
Update jsDelivr links

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,10 @@ IE 10+, Opera, Safari, Firefox & Chrome.
 
 ```html
 <!-- Before closing your <head> tag -->
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/jquery.timeliny/1.0.1/jquery.timeliny.min.css" />
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/jquery.timeliny@1.0.1/dist/jquery.timeliny.min.css" />
 
 <!-- Before closing your <body> tag -->
-<script src="https://cdn.jsdelivr.net/jquery.timeliny/1.0.1/jquery.timeliny.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/jquery.timeliny@1.0.1/dist/jquery.timeliny.min.js"></script>
 ```
 
 **Using NPM:**


### PR DESCRIPTION
[jsDelivr switched to a fully automated system](https://www.jsdelivr.com/features), that can serve files from npm and GitHub. This means all future releases will be available automatically, but will use a new link structure.

I updated the links now so you don't forget to do it when you release a new version.

You can find links for all files at https://www.jsdelivr.com/package/npm/jquery.timeliny.

Feel free to ping me if you have any questions regarding this change.